### PR TITLE
Build 3.0.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,13 @@
 REM Install the latest dotnet-core and SDK using dotnet-install scripts.
+REM For some reason, builders have problem deleting the `dotnet` directory that's created
+REM in this step, meaning only one build is guaranteed to succeed while others will
+REM fail because the directory exists but is unusable due to some deleted files.
+REM The solution is to create a random directory to store the dotnet SDK files.
 mkdir %BUILD_PREFIX% 2> NUL
-if exist %BUILD_PREFIX%\dotnet ( rmdir %BUILD_PREFIX%\dotnet /s /q )
 curl -L -o %BUILD_PREFIX%\dotnet-install.ps1 https://dot.net/v1/dotnet-install.ps1
-powershell %BUILD_PREFIX%\dotnet-install.ps1 -InstallDir %BUILD_PREFIX%\dotnet -Version latest
-set PATH=%BUILD_PREFIX%\dotnet;%PATH%
+set suffix=%random%
+powershell %BUILD_PREFIX%\dotnet-install.ps1 -InstallDir %BUILD_PREFIX%\dotnet-%suffix% -Version latest
+set PATH=%BUILD_PREFIX%\dotnet-%suffix%;%PATH%
 
 REM Now install the package
 %PYTHON% -m pip install . --no-deps -vv

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,11 @@
+REM Install the latest dotnet-core and SDK using dotnet-install scripts.
+mkdir %BUILD_PREFIX% 2> NUL
+if exist %BUILD_PREFIX%\dotnet ( rmdir %BUILD_PREFIX%\dotnet /s /q )
+curl -L -o %BUILD_PREFIX%\dotnet-install.ps1 https://dot.net/v1/dotnet-install.ps1
+powershell %BUILD_PREFIX%\dotnet-install.ps1 -InstallDir %BUILD_PREFIX%\dotnet -Version latest
+set PATH=%BUILD_PREFIX%\dotnet;%PATH%
+
+REM Now install the package
+%PYTHON% -m pip install . --no-deps -vv
+REM Remember to shutdown the build server so that future builds aren't affected.
+dotnet build-server shutdown

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,9 @@
+# Install the latest dotnet-core and SDK using dotnet-install scripts.
+mkdir -p $BUILD_PREFIX
+curl -L -o $BUILD_PREFIX/dotnet-install.sh https://dot.net/v1/dotnet-install.sh && chmod +x $BUILD_PREFIX/dotnet-install.sh
+source $BUILD_PREFIX/dotnet-install.sh --install-dir $BUILD_PREFIX/dotnet --version latest
+export PATH="$BUILD_PREFIX/dotnet:$PATH"
+export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+
+# Now install the package.
+$PYTHON -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,29 +11,26 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  # We skip for PPC64 and s390x since the dotnet binaries for this architecture aren't available.
+  skip: True # [ppc64le or s390x]
+  skip: True # [py<37]
 
 requirements:
-  build:
-    - dotnet-sdk
   host:
+    - python
     - pip
-    - python >=3.7,<3.12
-    - setuptools >=61
+    - setuptools
+    - setuptools_scm
     - wheel
+    - toml
   run:
     - clr_loader >=0.2.2,<0.3.0
-    - python >=3.7,<3.12
+    - python
 
 test:
-  imports:
-    - clr
   requires:
-    - dotnet-runtime
-    - importlib_resources
     - pip
-    - mono
+    - importlib_resources
   commands:
     - pip check
 
@@ -44,12 +41,14 @@ about:
   license_file: LICENSE
   summary: .Net and Mono integration for Python
   description: |
-    Python for .NET is a package that gives Python programmers nearly seamless integration with the
-     .NET Common Language Runtime (CLR) and provides a powerful application scripting tool for .NET
+      Python for .NET is a package that gives Python programmers nearly seamless integration with the
+      .NET Common Language Runtime (CLR) and provides a powerful application scripting tool for .NET
       developers.
   dev_url: https://github.com/pythonnet/pythonnet
+  doc_url: https://pythonnet.github.io/pythonnet/
 
 extra:
   recipe-maintainers:
     - m-rossi
     - bgruening
+    - sumit0190

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
     - pip check
 
 about:
-  home: http://pythonnet.github.io
+  home: https://pythonnet.github.io
   license: MIT
   license_family: MIT
   license_file: LICENSE

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -8,10 +8,4 @@ base_path = resources_files('pythonnet') / 'runtime'
 for ext in ['deps.json', 'dll', 'pdb']:
     if not (base_path / f'Python.Runtime.{ext}').exists():
         raise FileNotFoundError(f'DLL runtime/Python.Runtime.{ext} not found in package.')
-
-import clr
-import System.IO
-from System.IO import *
-
-# Check if import dotnet-modules work
-assert 'FileStream' in globals()
+print("DLLs found; test passed.")

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -3,18 +3,15 @@ try:
 except ImportError:
     from importlib_resources import files as resources_files
 
-
 # Check if DLL exist
 base_path = resources_files('pythonnet') / 'runtime'
 for ext in ['deps.json', 'dll', 'pdb']:
     if not (base_path / f'Python.Runtime.{ext}').exists():
         raise FileNotFoundError(f'DLL runtime/Python.Runtime.{ext} not found in package.')
 
-
 import clr
 import System.IO
 from System.IO import *
-
 
 # Check if import dotnet-modules work
 assert 'FileStream' in globals()


### PR DESCRIPTION
Just like `clr_loader` before, we build this package by downloading the `dotnet-sdk` on the fly. The built DLLs are verified in the test, but the primary functionality (that the runtime can be interfaced with) had to be manually verified because we lack a downloadable runtime in our defaults (`dotnet-runtime` or `mono`).